### PR TITLE
Review

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -33,6 +33,9 @@ def main(yale_phenotype, yale_all_variants, yale_most_damaging,
     most_damaging = md.create_most_damaging(UK_all_variants, uk_most_damaging, uk_phenotype,
                                             Yale_all_variants, yale_most_damaging, yale_phenotype,
                                             yale_survival, FILE_PATH)
+    # need to filter on depth so that we only calculate risks etc. on samples 
+    # we have sequenced successfully
+    most_damaging = most_damaging[most_damaging['Depth'] != 'LOW']
     # output both DataFrames as CSV file
     all_variants.to_csv(FILE_PATH+"/output/cleaned_data/All_Variants.csv")
     most_damaging.to_csv(FILE_PATH+"/output/cleaned_data/Most_Damaging.csv")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib>=1.5.1
 numpy>=1.13.1
-pandas>=0.18.1
+pandas>=0.21.0 
 Pillow>=2.8.2
 scipy>=0.18.1
 seaborn>=0.8.1

--- a/tables/risk_ratio.py
+++ b/tables/risk_ratio.py
@@ -44,7 +44,6 @@ def risk_ratio_table(df, outfile=None):
                         'RR(95% CI)', 'P-Value']
     rr_table = rr_table.set_index('')
     rr_table = rename_index(rr_table)
-    print('\nINFO: The risk ratio row for syndromic is calculated for MFS only')
     if outfile:
         rr_table.to_csv(outfile)
     return rr_table

--- a/tables/risk_ratio.py
+++ b/tables/risk_ratio.py
@@ -15,7 +15,8 @@ OPS = {
     "=": operator.eq,
     "!=": operator.ne,
     "&": operator.and_,
-    "|": operator.or_
+    "|": operator.or_,
+    "notna": pd.notna,
 }
 
 def risk_ratio_table(df, outfile=None):
@@ -32,7 +33,7 @@ def risk_ratio_table(df, outfile=None):
         ('primary diagnosis', '=', 'Dissection', None),
         ('maximal aortic size (cm)', '<=', 5, None),
         ('Long-term mortality (0=no, 1=yes)', '=', 0, 1),
-        ('Known Syndrome', '=', 'Marfan', None)
+        ('Known Syndrome', 'notna', None, None)
     ]
 
     all_table_rows = get_table_rows(df, test_groups)
@@ -65,7 +66,10 @@ def get_table_rows(df, test_groups):
         op = OPS[operation]
         rr, pval = pathogenic_risk_ratio(df, phenotype, op, exposed, not_exposed)
         plp_num = pathogenic_number(df, phenotype, op, exposed)
-        total = len(df[op(df[phenotype], exposed)])
+        if exposed is None:
+            total = len(df[op(df[phenotype])])
+        else:
+            total = len(df[op(df[phenotype], exposed)])
         table_rows.append([phenotype, total, plp_num, rr, pval])
     return table_rows
 
@@ -78,12 +82,15 @@ def pathogenic_number(df, col, op, value):
         op: operator string
         value: value col will be filtered for
     '''
-    group = df[op(df[col], value)]
+    if value is None:
+        group = df[op(df[col])]
+    else:
+        group = df[op(df[col], value)]
     plp_group = sf.validated_only(sf.pathogenic_only(group))
     percent_plp = len(plp_group) / len(group) * 100
     return '{0:d} ({1:.1f})'.format(len(plp_group), percent_plp)
 
-def pathogenic_risk_ratio(df, col, op, exposed_val, not_exposed_val=None):
+def pathogenic_risk_ratio(df, col, op, exposed_val=None, not_exposed_val=None):
     ''' Determine whether a phenotypic trait increases the 
         liklihood of carrying a causitive mutation for the
         disorder by performing riask ratio assessment
@@ -92,7 +99,8 @@ def pathogenic_risk_ratio(df, col, op, exposed_val, not_exposed_val=None):
         df: DataFrame
         col: phenotype column
         op: operator function
-        exposed_val: value of exposed group in column
+        exposed_val: value of exposed group in column (optional - will 
+                     test for True/False if None)
         not_exposed_val: value of non-exposed group (optional)
     Notes:
         The below example input will return the risk ratio
@@ -104,11 +112,15 @@ def pathogenic_risk_ratio(df, col, op, exposed_val, not_exposed_val=None):
         Risk ratio and p-value in a tuple
     '''    
     # exposed and non-exposed groups
-    exposed = df[op(df[col], exposed_val)]
-    if not_exposed_val:
-        not_exposed = df[op(df[col], not_exposed_val)]
+    if exposed_val is None:
+        exposed = df[op(df[col])]
+        not_exposed = df[~op(df[col])]
     else:
-        not_exposed = df[~op(df[col], exposed_val)]
+        exposed = df[op(df[col], exposed_val)]
+        if not_exposed_val:
+            not_exposed = df[op(df[col], not_exposed_val)]
+        else:
+            not_exposed = df[~op(df[col], exposed_val)]
         
     # Disease exposed and non-exposed groups
     d_exposed = len(sf.validated_only(sf.pathogenic_only(exposed)))


### PR DESCRIPTION
A couple of changes to address reviewer comments.

1. Stats on path/VUS/benign variants should only be calculated on individuals passing our depth threshold - therefore I am subsetting 'most_damaging' on Depth before writing and parsing these data.

2. Calculation of Risk Ratios for the 'Known Syndrome' column should identify all values which are not NaN as 'exposed', rather than just those that match 'Marfan'. Note, that in order to use the 'pd.notna' function, you may need to upgrade pandas.